### PR TITLE
feat: Handle also SHA Password hashes and handle salt dynamically

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/imdario/mergo v0.3.12
 	github.com/inhies/go-bytesize v0.0.0-20210819104631-275770b98743
 	github.com/jarcoal/httpmock v1.0.5
+	github.com/jsimonetti/pwscheme v0.0.0-20220922140336-67a4d090f150
 	github.com/jteeuwen/go-bindata v3.0.7+incompatible
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/knadh/koanf v1.4.0
@@ -216,7 +217,6 @@ require (
 	github.com/joho/godotenv v1.4.0 // indirect
 	github.com/jonboulle/clockwork v0.2.2 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
-	github.com/jsimonetti/pwscheme v0.0.0-20220922140336-67a4d090f150 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/kr/pretty v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1084,8 +1084,6 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/jpillora/backoff v0.0.0-20180909062703-3050d21c67d7/go.mod h1:2iMrUgbbvHEiQClaW2NsSzMyGHqN+rDFqY705q49KG0=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
-github.com/jsimonetti/pwscheme v0.0.0-20220125093853-4d9895f5db73 h1:ZhC4QngptYaGx53+ph1RjxcH8fkCozBaY+935TNX4i8=
-github.com/jsimonetti/pwscheme v0.0.0-20220125093853-4d9895f5db73/go.mod h1:t0Q9JvoMTfTYdAWIk2MF69iz+Qpdk9D+PgVu6fVmaDI=
 github.com/jsimonetti/pwscheme v0.0.0-20220922140336-67a4d090f150 h1:ta6N7DaOQEACq28cLa0iRqXIbchByN9Lfll08CT2GBc=
 github.com/jsimonetti/pwscheme v0.0.0-20220922140336-67a4d090f150/go.mod h1:SiNTKDgjKQORnazFVHXhpny7UtU0iJOqtxd7R7sCfDI=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -1882,8 +1880,7 @@ golang.org/x/crypto v0.0.0-20210920023735-84f357641f63/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220517005047-85d78b3ac167/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.0.0-20220817201139-bc19a97f63c8 h1:GIAS/yBem/gq2MUqgNIzUHW7cJMmx3TGZOrnyYaNQ6c=
-golang.org/x/crypto v0.0.0-20220817201139-bc19a97f63c8/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20220919173607-35f4265a4bc0 h1:a5Yg6ylndHHYJqIPrdq0AhvR6KTvDTAvgBtaidhEevY=
 golang.org/x/crypto v0.0.0-20220919173607-35f4265a4bc0/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -2000,8 +1997,7 @@ golang.org/x/net v0.0.0-20220325170049-de3da57026de/go.mod h1:CfG3xpIq0wQ8r1q4Su
 golang.org/x/net v0.0.0-20220412020605-290c469a71a5/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220607020251-c690dde0001d/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
-golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b h1:ZmngSVLe/wycRns9MKikG9OWIEjGcGAkacif7oYQaUY=
-golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
+golang.org/x/net v0.0.0-20220921155015-db77216a4ee9 h1:SdDGdqRuKrF2R4XGcnPzcvZ63c/55GvhoHUus0o+BNI=
 golang.org/x/net v0.0.0-20220921155015-db77216a4ee9/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181106182150-f42d05182288/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -2052,8 +2048,8 @@ golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXR
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210317153231-de623e64d2a6/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/term v0.0.0-20220919170432-7a66f970e087 h1:tPwmk4vmvVCMdr98VgL4JH+qZxPL8fqlUOHnyOM8N3w=
 golang.org/x/term v0.0.0-20220919170432-7a66f970e087/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/hash/hash_comparator.go
+++ b/hash/hash_comparator.go
@@ -406,11 +406,12 @@ func compareSHAHelper(hasher string, raw []byte, hash []byte) error {
 		return errors.WithStack(ErrUnknownHashAlgorithm)
 	}
 
-	// sum is uint8, encoded in base16
+	encodedHash := []byte(base64.StdEncoding.EncodeToString(hash))
+	newEncodedHash := []byte(base64.StdEncoding.EncodeToString(sha))
 
 	// Check that the contents of the hashed passwords are identical.
 	// subtle.ConstantTimeCompare() is used to help prevent timing attacks.
-	if subtle.ConstantTimeCompare([]byte(base64.StdEncoding.EncodeToString(sha)), []byte(base64.StdEncoding.EncodeToString(hash))) == 1 {
+	if subtle.ConstantTimeCompare(encodedHash, newEncodedHash) == 1 {
 		return nil
 	}
 	return errors.WithStack(ErrMismatchedHashAndPassword)

--- a/hash/hash_comparator.go
+++ b/hash/hash_comparator.go
@@ -387,6 +387,7 @@ func decodeSHAHash(encodedHash string) (hasher, pf, salt, hash []byte, err error
 	return hasher, pf, salt, hash, nil
 }
 
+// used for CompareSHA and CompareSSHA CompareSSHA256 CompareSSHA512
 func compareSHAHelper(hasher string, raw []byte, hash []byte) error {
 
 	var sha []byte

--- a/hash/hasher_test.go
+++ b/hash/hasher_test.go
@@ -243,49 +243,38 @@ func TestCompare(t *testing.T) {
 	assert.Error(t, hash.Compare(context.Background(), []byte("tesu"), []byte("$scrypt$ln=16384,r=8,p=1$2npRo7P03Mt8keSoMbyD/tKFWyUzjiQf2svUaNDSrhA=$MiCzNcIplSMqSBrm4HckjYqYhaVPPjTARTzwB1cVNYE=")))
 	assert.Error(t, hash.Compare(context.Background(), []byte("tesu"), []byte("$scrypt$ln=abc,r=8,p=1$2npRo7P03Mt8keSoMbyD/tKFWyUzjiQf2svUaNDSrhA=$MiCzNcIplSMqSBrm4HckjYqYhaVPPjTARTzwB1cVNYE=")))
 
-	// SSHA
 	assert.Nil(t, hash.Compare(context.Background(), []byte("test123"), []byte("{SSHA}JFZFs0oHzxbMwkSJmYVeI8MnTDy/276a")))
 	assert.Nil(t, hash.CompareSSHA(context.Background(), []byte("test123"), []byte("{SSHA}JFZFs0oHzxbMwkSJmYVeI8MnTDy/276a")))
 	assert.Error(t, hash.CompareSSHA(context.Background(), []byte("badtest"), []byte("{SSHA}JFZFs0oHzxbMwkSJmYVeI8MnTDy/276a")))
 
-	// SSHA256
 	assert.Nil(t, hash.Compare(context.Background(), []byte("test123"), []byte("{SSHA256}czO44OTV17PcF1cRxWrLZLy9xHd7CWyVYplr1rOhuMlx/7IK")))
 	assert.Nil(t, hash.CompareSSHA256(context.Background(), []byte("test123"), []byte("{SSHA256}czO44OTV17PcF1cRxWrLZLy9xHd7CWyVYplr1rOhuMlx/7IK")))
 	assert.Error(t, hash.CompareSSHA256(context.Background(), []byte("badtest"), []byte("{SSHA256}czO44OTV17PcF1cRxWrLZLy9xHd7CWyVYplr1rOhuMlx/7IK")))
 
-	// SSHA512
 	assert.Nil(t, hash.Compare(context.Background(), []byte("test123"), []byte("{SSHA512}xPUl/px+1cG55rUH4rzcwxdOIPSB2TingLpiJJumN2xyDWN4Ix1WQG3ihnvHaWUE8MYNkvMi5rf0C9NYixHsE6Yh59M=")))
 	assert.Nil(t, hash.CompareSSHA512(context.Background(), []byte("test123"), []byte("{SSHA512}xPUl/px+1cG55rUH4rzcwxdOIPSB2TingLpiJJumN2xyDWN4Ix1WQG3ihnvHaWUE8MYNkvMi5rf0C9NYixHsE6Yh59M=")))
 	assert.Error(t, hash.CompareSSHA512(context.Background(), []byte("badtest"), []byte("{SSHA512}xPUl/px+1cG55rUH4rzcwxdOIPSB2TingLpiJJumN2xyDWN4Ix1WQG3ihnvHaWUE8MYNkvMi5rf0C9NYixHsE6Yh59M=")))
-
-	//SHA-1
 
 	//pf: {SALT}{PASSWORD}
 	assert.Nil(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha1$pf=e1NBTFR9e1BBU1NXT1JEfQ==$NW9wbWtnejAzcg==$2qU2SGWP8viTM1md3FiI3+rjWXQ=")))
 	assert.Error(t, hash.Compare(context.Background(), []byte("wrongpass"), []byte("$sha1$pf=e1NBTFR9e1BBU1NXT1JEfQ==$NW9wbWtnejAzcg==$2qU2SGWP8viTM1md3FiI3+rjWXQ=")))
 	assert.Error(t, hash.Compare(context.Background(), []byte("tset"), []byte("$sha1$pf=e1NBTFR9e1BBU1NXT1JEfQ==$NW9wbWtnejAzcg==$2qU2SGWP8viTM1md3FiI3+rjWXQ=")))
-	assert.Error(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha1$pf=e1NBTFR9e1BBU1NXT1JEfQ==$cDJvb3ZrZGJ6cQ==$2qU2SGWP8viTM1md3FiI3+rjWXQ="))) // wrong salt
-	assert.Error(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha1$pf=e1NBTFR9e1BBU1NXT1JEfQ==$5opmkgz03r$2qU2SGWP8viTM1md3FiI3+rjWXQ=")))       // salt not encoded
-
+	// wrong salt
+	assert.Error(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha1$pf=e1NBTFR9e1BBU1NXT1JEfQ==$cDJvb3ZrZGJ6cQ==$2qU2SGWP8viTM1md3FiI3+rjWXQ=")))
+	// salt not encoded
+	assert.Error(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha1$pf=e1NBTFR9e1BBU1NXT1JEfQ==$5opmkgz03r$2qU2SGWP8viTM1md3FiI3+rjWXQ=")))
 	assert.Nil(t, hash.Compare(context.Background(), []byte("BwS^514g^cv@Z"), []byte("$sha1$pf=e1NBTFR9e1BBU1NXT1JEfQ==$NW9wbWtnejAzcg==$99h9net4BXl7qdTRaiGUobLROxM=")))
-
 	// no format string
 	assert.Error(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha1$pf=$NW9wbWtnejAzcg==$2qU2SGWP8viTM1md3FiI3+rjWXQ=")))
 	assert.Error(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha1$$NW9wbWtnejAzcg==$2qU2SGWP8viTM1md3FiI3+rjWXQ=")))
-
 	// wrong number of parameters
 	assert.Error(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha1$NW9wbWtnejAzcg==$2qU2SGWP8viTM1md3FiI3+rjWXQ=")))
-
 	// pf: ??staticPrefix??{SALT}{PASSWORD}
 	assert.Nil(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha1$pf=Pz9zdGF0aWNQcmVmaXg/P3tTQUxUfXtQQVNTV09SRH0=$NW9wbWtnejAzcg==$SAAxMUn7jxckQXkBmsVF0nHwqso=")))
-
 	// pf: {PASSWORD}%%{SALT}
 	assert.Nil(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha1$pf=e1BBU1NXT1JEfSUle1NBTFR9$NW9wbWtnejAzcg==$YX0AW8/MW5ojUlnzTaR43ucHCog=")))
-
 	// pf: ${PASSWORD}${SALT}$
 	assert.Nil(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha1$pf=JHtQQVNTV09SRH0ke1NBTFR9JA==$NW9wbWtnejAzcg==$iE5n1yjX3oAdxRHwZ4u57I4LpQo=")))
-
-	//SHA-256
 
 	//pf: {SALT}{PASSWORD}
 	assert.Nil(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha256$pf=e1NBTFR9e1BBU1NXT1JEfQ==$NW9wbWtnejAzcg==$0gfRVLCvtBCk20udLDEY5vNhujWx7RGjwRIS1ebMsLY=")))
@@ -293,8 +282,6 @@ func TestCompare(t *testing.T) {
 	assert.Error(t, hash.Compare(context.Background(), []byte("wrongpass"), []byte("$sha256$pf=e1NBTFR9e1BBU1NXT1JEfQ==$NW9wbWtnejAzcg==$0gfRVLCvtBCk20udLDEY5vNhujWx7RGjwRIS1ebMsLY=")))
 	//pf: {SALT}$${PASSWORD}
 	assert.Nil(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha256$pf=e1NBTFR9JCR7UEFTU1dPUkR9$NW9wbWtnejAzcg==$HokCOi9OtiZaZRvnkgemV3B4UUHpI7kA8zq/EZWH2NY=")))
-
-	//SHA-512
 
 	//pf: {SALT}{PASSWORD}
 	assert.Nil(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha512$pf=e1NBTFR9e1BBU1NXT1JEfQ==$NW9wbWtnejAzcg==$6ctpVuApMNp0CgBXcdHw/GC562eFEFGr4gpgANX8ZYsX+j5B19IkdmOY2Fytsz3QUwSWdGcUjbqwgJGTH0UYvw==")))

--- a/hash/hasher_test.go
+++ b/hash/hasher_test.go
@@ -198,6 +198,9 @@ func TestPbkdf2Hasher(t *testing.T) {
 func TestCompare(t *testing.T) {
 	assert.Error(t, hash.Compare(context.Background(), []byte("test"), []byte("$unknown$12$o6hx.Wog/wvFSkT/Bp/6DOxCtLRTDj7lm9on9suF/WaCGNVHbkfL6")))
 
+	assert.Nil(t, hash.Compare(context.Background(), []byte("123456"), []byte("$serlo$a40c10cfe4$85396a8a48e3485a0ae374b857bfadf02c8cbf0d")))
+	assert.Nil(t, hash.CompareSerlo(context.Background(), []byte("123456"), []byte("$serlo$a40c10cfe4$85396a8a48e3485a0ae374b857bfadf02c8cbf0d")))
+
 	assert.Nil(t, hash.Compare(context.Background(), []byte("test"), []byte("$2a$12$o6hx.Wog/wvFSkT/Bp/6DOxCtLRTDj7lm9on9suF/WaCGNVHbkfL6")))
 	assert.Nil(t, hash.CompareBcrypt(context.Background(), []byte("test"), []byte("$2a$12$o6hx.Wog/wvFSkT/Bp/6DOxCtLRTDj7lm9on9suF/WaCGNVHbkfL6")))
 	assert.Error(t, hash.Compare(context.Background(), []byte("test"), []byte("$2a$12$o6hx.Wog/wvFSkT/Bp/6DOxCtLRTDj7lm9on9suF/WaCGNVHbkfL7")))

--- a/hash/hasher_test.go
+++ b/hash/hasher_test.go
@@ -198,14 +198,6 @@ func TestPbkdf2Hasher(t *testing.T) {
 func TestCompare(t *testing.T) {
 	assert.Error(t, hash.Compare(context.Background(), []byte("test"), []byte("$unknown$12$o6hx.Wog/wvFSkT/Bp/6DOxCtLRTDj7lm9on9suF/WaCGNVHbkfL6")))
 
-	// $sha1$pf=<salting-format>$<salt>$<hash>
-	// pf   {SALT}{PASSWORD}
-	// salt a40c10cfe4
-	// hash 85396a8a48e3485a0ae374b857bfadf02c8cbf0d
-
-	assert.Nil(t, hash.Compare(context.Background(), []byte("123456"), []byte("$sha1$pf=e1NBTFR9e1BBU1NXT1JEfQ==$YTQwYzEwY2ZlNA==$ODUzOTZhOGE0OGUzNDg1YTBhZTM3NGI4NTdiZmFkZjAyYzhjYmYwZA==")))
-	assert.Nil(t, hash.CompareSHA1(context.Background(), []byte("123456"), []byte("$sha1$pf=e1NBTFR9e1BBU1NXT1JEfQ==$YTQwYzEwY2ZlNA==$ODUzOTZhOGE0OGUzNDg1YTBhZTM3NGI4NTdiZmFkZjAyYzhjYmYwZA==")))
-
 	assert.Nil(t, hash.Compare(context.Background(), []byte("test"), []byte("$2a$12$o6hx.Wog/wvFSkT/Bp/6DOxCtLRTDj7lm9on9suF/WaCGNVHbkfL6")))
 	assert.Nil(t, hash.CompareBcrypt(context.Background(), []byte("test"), []byte("$2a$12$o6hx.Wog/wvFSkT/Bp/6DOxCtLRTDj7lm9on9suF/WaCGNVHbkfL6")))
 	assert.Error(t, hash.Compare(context.Background(), []byte("test"), []byte("$2a$12$o6hx.Wog/wvFSkT/Bp/6DOxCtLRTDj7lm9on9suF/WaCGNVHbkfL7")))
@@ -262,4 +254,48 @@ func TestCompare(t *testing.T) {
 	assert.Nil(t, hash.Compare(context.Background(), []byte("test123"), []byte("{SSHA512}xPUl/px+1cG55rUH4rzcwxdOIPSB2TingLpiJJumN2xyDWN4Ix1WQG3ihnvHaWUE8MYNkvMi5rf0C9NYixHsE6Yh59M=")))
 	assert.Nil(t, hash.CompareSSHA512(context.Background(), []byte("test123"), []byte("{SSHA512}xPUl/px+1cG55rUH4rzcwxdOIPSB2TingLpiJJumN2xyDWN4Ix1WQG3ihnvHaWUE8MYNkvMi5rf0C9NYixHsE6Yh59M=")))
 	assert.Error(t, hash.CompareSSHA512(context.Background(), []byte("badtest"), []byte("{SSHA512}xPUl/px+1cG55rUH4rzcwxdOIPSB2TingLpiJJumN2xyDWN4Ix1WQG3ihnvHaWUE8MYNkvMi5rf0C9NYixHsE6Yh59M=")))
+
+	// pf   {PASSWORD}
+	// pass test
+	// hash a94a8fe5ccb19ba61c4c0873d391e987982fbbd3
+	// salt 5opmkgz03r
+	assert.Nil(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha1$pf=e1BBU1NXT1JEfQ==$NW9wbWtnejAzcg==$YTk0YThmZTVjY2IxOWJhNjFjNGMwODczZDM5MWU5ODc5ODJmYmJkMw==")))
+	assert.Nil(t, hash.CompareSHA1(context.Background(), []byte("test"), []byte("$sha1$pf=e1BBU1NXT1JEfQ==$NW9wbWtnejAzcg==$YTk0YThmZTVjY2IxOWJhNjFjNGMwODczZDM5MWU5ODc5ODJmYmJkMw==")))
+
+	// pf   {PASSWORD}{SALT}
+	// pass test
+	// hash af487fbccf86f4b2acd813881d17de88312f55e4
+	// salt 5opmkgz03r
+	assert.Nil(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha1$pf=e1BBU1NXT1JEfXtTQUxUfQ==$NW9wbWtnejAzcg==$YWY0ODdmYmNjZjg2ZjRiMmFjZDgxMzg4MWQxN2RlODgzMTJmNTVlNA==")))
+
+	// $sha1$pf=<salting-format>$<salt>$<hash>
+	// pf   ??staticPrefix??{SALT}{PASSWORD}
+	// pass test
+	// hash 4800313149fb8f17244179019ac545d271f0aaca
+	// salt 5opmkgz03r
+	assert.Nil(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha1$pf=Pz9zdGF0aWNQcmVmaXg/P3tTQUxUfXtQQVNTV09SRH0=$NW9wbWtnejAzcg==$NDgwMDMxMzE0OWZiOGYxNzI0NDE3OTAxOWFjNTQ1ZDI3MWYwYWFjYQ==")))
+
+	// wrong password
+	assert.Error(t, hash.Compare(context.Background(), []byte("test2"), []byte("$sha1$pf=e1BBU1NXT1JEfXtTQUxUfQ==$NW9wbWtnejAzcg==$YWY0ODdmYmNjZjg2ZjRiMmFjZDgxMzg4MWQxN2RlODgzMTJmNTVlNA==")))
+
+	// wrong salt
+	assert.Error(t, hash.Compare(context.Background(), []byte("test2"), []byte("$sha1$pf=e1BBU1NXT1JEfXtTQUxUfQ==$cDJvb3ZrZGJ6cQ==$YWY0ODdmYmNjZjg2ZjRiMmFjZDgxMzg4MWQxN2RlODgzMTJmNTVlNA==")))
+
+	// salt not b64 encoded
+	assert.Error(t, hash.Compare(context.Background(), []byte("test2"), []byte("$sha1$pf=e1BBU1NXT1JEfXtTQUxUfQ==$NW9wbWtnejAzcg==$YWY0ODdmYmNjZjg2ZjRiMmFjZDgxMzg4MWQxN2RlODgzMTJmNTVlNA==")))
+
+	// no format string
+	assert.Error(t, hash.Compare(context.Background(), []byte("test2"), []byte("$sha1$pf=$NW9wbWtnejAzcg==$YWY0ODdmYmNjZjg2ZjRiMmFjZDgxMzg4MWQxN2RlODgzMTJmNTVlNA==")))
+	assert.Error(t, hash.Compare(context.Background(), []byte("test2"), []byte("$sha1$$NW9wbWtnejAzcg==$YWY0ODdmYmNjZjg2ZjRiMmFjZDgxMzg4MWQxN2RlODgzMTJmNTVlNA==")))
+
+	// wrong number of parameters
+	assert.Error(t, hash.Compare(context.Background(), []byte("test2"), []byte("$sha1$NW9wbWtnejAzcg==$YWY0ODdmYmNjZjg2ZjRiMmFjZDgxMzg4MWQxN2RlODgzMTJmNTVlNA==")))
+
+	// pf   {PASSWORD}%%{SALT}
+	assert.Nil(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha1$pf=e1BBU1NXT1JEfSUle1NBTFR9$NW9wbWtnejAzcg==$NjE3ZDAwNWJjZmNjNWI5YTIzNTI1OWYzNGRhNDc4ZGVlNzA3MGE4OA==")))
+
+	// TODO: format strings with $ fail for some reason
+	// pf   ${PASSWORD}{SALT}$
+	assert.Nil(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha1$pf=JHtQQVNTV09SRH17U0FMVH0k$NW9wbWtnejAzcg==$M2NkZjI5MzZkYTJmYzU1NmJmYTUzM2FiMWViNTljZTcxMGFjODBlNQ==")))
+
 }

--- a/hash/hasher_test.go
+++ b/hash/hasher_test.go
@@ -201,7 +201,7 @@ func TestCompare(t *testing.T) {
 	// $sha1$pf=<salting-format>$<salt>$<hash>
 	// pf   {SALT}{PASSWORD}
 	// salt a40c10cfe4
-	// pass 85396a8a48e3485a0ae374b857bfadf02c8cbf0d
+	// hash 85396a8a48e3485a0ae374b857bfadf02c8cbf0d
 
 	assert.Nil(t, hash.Compare(context.Background(), []byte("123456"), []byte("$sha1$pf=e1NBTFR9e1BBU1NXT1JEfQ==$YTQwYzEwY2ZlNA==$ODUzOTZhOGE0OGUzNDg1YTBhZTM3NGI4NTdiZmFkZjAyYzhjYmYwZA==")))
 	assert.Nil(t, hash.CompareSHA1(context.Background(), []byte("123456"), []byte("$sha1$pf=e1NBTFR9e1BBU1NXT1JEfQ==$YTQwYzEwY2ZlNA==$ODUzOTZhOGE0OGUzNDg1YTBhZTM3NGI4NTdiZmFkZjAyYzhjYmYwZA==")))

--- a/hash/hasher_test.go
+++ b/hash/hasher_test.go
@@ -198,8 +198,13 @@ func TestPbkdf2Hasher(t *testing.T) {
 func TestCompare(t *testing.T) {
 	assert.Error(t, hash.Compare(context.Background(), []byte("test"), []byte("$unknown$12$o6hx.Wog/wvFSkT/Bp/6DOxCtLRTDj7lm9on9suF/WaCGNVHbkfL6")))
 
-	// assert.Nil(t, hash.Compare(context.Background(), []byte("123456"), []byte("$sha1$a40c10cfe4$85396a8a48e3485a0ae374b857bfadf02c8cbf0d"))) // TODO: split hash from our string, add pf format string (b64 encoded)
-	// assert.Nil(t, hash.CompareSHA1(context.Background(), []byte("123456"), []byte("$sha1$a40c10cfe4$85396a8a48e3485a0ae374b857bfadf02c8cbf0d")))
+	// $sha1$pf=<salting-format>$<salt>$<hash>
+	// pf   {SALT}{PASSWORD}
+	// salt a40c10cfe4
+	// pass 85396a8a48e3485a0ae374b857bfadf02c8cbf0d
+
+	assert.Nil(t, hash.Compare(context.Background(), []byte("123456"), []byte("$sha1$pf=e1NBTFR9e1BBU1NXT1JEfQ==$YTQwYzEwY2ZlNA==$ODUzOTZhOGE0OGUzNDg1YTBhZTM3NGI4NTdiZmFkZjAyYzhjYmYwZA==")))
+	assert.Nil(t, hash.CompareSHA1(context.Background(), []byte("123456"), []byte("$sha1$pf=e1NBTFR9e1BBU1NXT1JEfQ==$YTQwYzEwY2ZlNA==$ODUzOTZhOGE0OGUzNDg1YTBhZTM3NGI4NTdiZmFkZjAyYzhjYmYwZA==")))
 
 	assert.Nil(t, hash.Compare(context.Background(), []byte("test"), []byte("$2a$12$o6hx.Wog/wvFSkT/Bp/6DOxCtLRTDj7lm9on9suF/WaCGNVHbkfL6")))
 	assert.Nil(t, hash.CompareBcrypt(context.Background(), []byte("test"), []byte("$2a$12$o6hx.Wog/wvFSkT/Bp/6DOxCtLRTDj7lm9on9suF/WaCGNVHbkfL6")))

--- a/hash/hasher_test.go
+++ b/hash/hasher_test.go
@@ -198,8 +198,8 @@ func TestPbkdf2Hasher(t *testing.T) {
 func TestCompare(t *testing.T) {
 	assert.Error(t, hash.Compare(context.Background(), []byte("test"), []byte("$unknown$12$o6hx.Wog/wvFSkT/Bp/6DOxCtLRTDj7lm9on9suF/WaCGNVHbkfL6")))
 
-	assert.Nil(t, hash.Compare(context.Background(), []byte("123456"), []byte("$serlo$a40c10cfe4$85396a8a48e3485a0ae374b857bfadf02c8cbf0d")))
-	assert.Nil(t, hash.CompareSerlo(context.Background(), []byte("123456"), []byte("$serlo$a40c10cfe4$85396a8a48e3485a0ae374b857bfadf02c8cbf0d")))
+	// assert.Nil(t, hash.Compare(context.Background(), []byte("123456"), []byte("$sha1$a40c10cfe4$85396a8a48e3485a0ae374b857bfadf02c8cbf0d"))) // TODO: split hash from our string, add pf format string (b64 encoded)
+	// assert.Nil(t, hash.CompareSHA1(context.Background(), []byte("123456"), []byte("$sha1$a40c10cfe4$85396a8a48e3485a0ae374b857bfadf02c8cbf0d")))
 
 	assert.Nil(t, hash.Compare(context.Background(), []byte("test"), []byte("$2a$12$o6hx.Wog/wvFSkT/Bp/6DOxCtLRTDj7lm9on9suF/WaCGNVHbkfL6")))
 	assert.Nil(t, hash.CompareBcrypt(context.Background(), []byte("test"), []byte("$2a$12$o6hx.Wog/wvFSkT/Bp/6DOxCtLRTDj7lm9on9suF/WaCGNVHbkfL6")))

--- a/hash/hasher_test.go
+++ b/hash/hasher_test.go
@@ -243,59 +243,63 @@ func TestCompare(t *testing.T) {
 	assert.Error(t, hash.Compare(context.Background(), []byte("tesu"), []byte("$scrypt$ln=16384,r=8,p=1$2npRo7P03Mt8keSoMbyD/tKFWyUzjiQf2svUaNDSrhA=$MiCzNcIplSMqSBrm4HckjYqYhaVPPjTARTzwB1cVNYE=")))
 	assert.Error(t, hash.Compare(context.Background(), []byte("tesu"), []byte("$scrypt$ln=abc,r=8,p=1$2npRo7P03Mt8keSoMbyD/tKFWyUzjiQf2svUaNDSrhA=$MiCzNcIplSMqSBrm4HckjYqYhaVPPjTARTzwB1cVNYE=")))
 
+	// SSHA
 	assert.Nil(t, hash.Compare(context.Background(), []byte("test123"), []byte("{SSHA}JFZFs0oHzxbMwkSJmYVeI8MnTDy/276a")))
 	assert.Nil(t, hash.CompareSSHA(context.Background(), []byte("test123"), []byte("{SSHA}JFZFs0oHzxbMwkSJmYVeI8MnTDy/276a")))
 	assert.Error(t, hash.CompareSSHA(context.Background(), []byte("badtest"), []byte("{SSHA}JFZFs0oHzxbMwkSJmYVeI8MnTDy/276a")))
 
+	// SSHA256
 	assert.Nil(t, hash.Compare(context.Background(), []byte("test123"), []byte("{SSHA256}czO44OTV17PcF1cRxWrLZLy9xHd7CWyVYplr1rOhuMlx/7IK")))
 	assert.Nil(t, hash.CompareSSHA256(context.Background(), []byte("test123"), []byte("{SSHA256}czO44OTV17PcF1cRxWrLZLy9xHd7CWyVYplr1rOhuMlx/7IK")))
 	assert.Error(t, hash.CompareSSHA256(context.Background(), []byte("badtest"), []byte("{SSHA256}czO44OTV17PcF1cRxWrLZLy9xHd7CWyVYplr1rOhuMlx/7IK")))
 
+	// SSHA512
 	assert.Nil(t, hash.Compare(context.Background(), []byte("test123"), []byte("{SSHA512}xPUl/px+1cG55rUH4rzcwxdOIPSB2TingLpiJJumN2xyDWN4Ix1WQG3ihnvHaWUE8MYNkvMi5rf0C9NYixHsE6Yh59M=")))
 	assert.Nil(t, hash.CompareSSHA512(context.Background(), []byte("test123"), []byte("{SSHA512}xPUl/px+1cG55rUH4rzcwxdOIPSB2TingLpiJJumN2xyDWN4Ix1WQG3ihnvHaWUE8MYNkvMi5rf0C9NYixHsE6Yh59M=")))
 	assert.Error(t, hash.CompareSSHA512(context.Background(), []byte("badtest"), []byte("{SSHA512}xPUl/px+1cG55rUH4rzcwxdOIPSB2TingLpiJJumN2xyDWN4Ix1WQG3ihnvHaWUE8MYNkvMi5rf0C9NYixHsE6Yh59M=")))
 
-	// pf   {PASSWORD}
-	// pass test
-	// hash a94a8fe5ccb19ba61c4c0873d391e987982fbbd3
-	// salt 5opmkgz03r
-	assert.Nil(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha1$pf=e1BBU1NXT1JEfQ==$NW9wbWtnejAzcg==$YTk0YThmZTVjY2IxOWJhNjFjNGMwODczZDM5MWU5ODc5ODJmYmJkMw==")))
-	assert.Nil(t, hash.CompareSHA1(context.Background(), []byte("test"), []byte("$sha1$pf=e1BBU1NXT1JEfQ==$NW9wbWtnejAzcg==$YTk0YThmZTVjY2IxOWJhNjFjNGMwODczZDM5MWU5ODc5ODJmYmJkMw==")))
+	//SHA-1
 
-	// pf   {PASSWORD}{SALT}
-	// pass test
-	// hash af487fbccf86f4b2acd813881d17de88312f55e4
-	// salt 5opmkgz03r
-	assert.Nil(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha1$pf=e1BBU1NXT1JEfXtTQUxUfQ==$NW9wbWtnejAzcg==$YWY0ODdmYmNjZjg2ZjRiMmFjZDgxMzg4MWQxN2RlODgzMTJmNTVlNA==")))
+	//pf: {SALT}{PASSWORD}
+	assert.Nil(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha1$pf=e1NBTFR9e1BBU1NXT1JEfQ==$NW9wbWtnejAzcg==$2qU2SGWP8viTM1md3FiI3+rjWXQ=")))
+	assert.Error(t, hash.Compare(context.Background(), []byte("wrongpass"), []byte("$sha1$pf=e1NBTFR9e1BBU1NXT1JEfQ==$NW9wbWtnejAzcg==$2qU2SGWP8viTM1md3FiI3+rjWXQ=")))
+	assert.Error(t, hash.Compare(context.Background(), []byte("tset"), []byte("$sha1$pf=e1NBTFR9e1BBU1NXT1JEfQ==$NW9wbWtnejAzcg==$2qU2SGWP8viTM1md3FiI3+rjWXQ=")))
+	assert.Error(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha1$pf=e1NBTFR9e1BBU1NXT1JEfQ==$cDJvb3ZrZGJ6cQ==$2qU2SGWP8viTM1md3FiI3+rjWXQ="))) // wrong salt
+	assert.Error(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha1$pf=e1NBTFR9e1BBU1NXT1JEfQ==$5opmkgz03r$2qU2SGWP8viTM1md3FiI3+rjWXQ=")))       // salt not encoded
 
-	// $sha1$pf=<salting-format>$<salt>$<hash>
-	// pf   ??staticPrefix??{SALT}{PASSWORD}
-	// pass test
-	// hash 4800313149fb8f17244179019ac545d271f0aaca
-	// salt 5opmkgz03r
-	assert.Nil(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha1$pf=Pz9zdGF0aWNQcmVmaXg/P3tTQUxUfXtQQVNTV09SRH0=$NW9wbWtnejAzcg==$NDgwMDMxMzE0OWZiOGYxNzI0NDE3OTAxOWFjNTQ1ZDI3MWYwYWFjYQ==")))
-
-	// wrong password
-	assert.Error(t, hash.Compare(context.Background(), []byte("test2"), []byte("$sha1$pf=e1BBU1NXT1JEfXtTQUxUfQ==$NW9wbWtnejAzcg==$YWY0ODdmYmNjZjg2ZjRiMmFjZDgxMzg4MWQxN2RlODgzMTJmNTVlNA==")))
-
-	// wrong salt
-	assert.Error(t, hash.Compare(context.Background(), []byte("test2"), []byte("$sha1$pf=e1BBU1NXT1JEfXtTQUxUfQ==$cDJvb3ZrZGJ6cQ==$YWY0ODdmYmNjZjg2ZjRiMmFjZDgxMzg4MWQxN2RlODgzMTJmNTVlNA==")))
-
-	// salt not b64 encoded
-	assert.Error(t, hash.Compare(context.Background(), []byte("test2"), []byte("$sha1$pf=e1BBU1NXT1JEfXtTQUxUfQ==$NW9wbWtnejAzcg==$YWY0ODdmYmNjZjg2ZjRiMmFjZDgxMzg4MWQxN2RlODgzMTJmNTVlNA==")))
+	assert.Nil(t, hash.Compare(context.Background(), []byte("BwS^514g^cv@Z"), []byte("$sha1$pf=e1NBTFR9e1BBU1NXT1JEfQ==$NW9wbWtnejAzcg==$99h9net4BXl7qdTRaiGUobLROxM=")))
 
 	// no format string
-	assert.Error(t, hash.Compare(context.Background(), []byte("test2"), []byte("$sha1$pf=$NW9wbWtnejAzcg==$YWY0ODdmYmNjZjg2ZjRiMmFjZDgxMzg4MWQxN2RlODgzMTJmNTVlNA==")))
-	assert.Error(t, hash.Compare(context.Background(), []byte("test2"), []byte("$sha1$$NW9wbWtnejAzcg==$YWY0ODdmYmNjZjg2ZjRiMmFjZDgxMzg4MWQxN2RlODgzMTJmNTVlNA==")))
+	assert.Error(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha1$pf=$NW9wbWtnejAzcg==$2qU2SGWP8viTM1md3FiI3+rjWXQ=")))
+	assert.Error(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha1$$NW9wbWtnejAzcg==$2qU2SGWP8viTM1md3FiI3+rjWXQ=")))
 
 	// wrong number of parameters
-	assert.Error(t, hash.Compare(context.Background(), []byte("test2"), []byte("$sha1$NW9wbWtnejAzcg==$YWY0ODdmYmNjZjg2ZjRiMmFjZDgxMzg4MWQxN2RlODgzMTJmNTVlNA==")))
+	assert.Error(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha1$NW9wbWtnejAzcg==$2qU2SGWP8viTM1md3FiI3+rjWXQ=")))
 
-	// pf   {PASSWORD}%%{SALT}
-	assert.Nil(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha1$pf=e1BBU1NXT1JEfSUle1NBTFR9$NW9wbWtnejAzcg==$NjE3ZDAwNWJjZmNjNWI5YTIzNTI1OWYzNGRhNDc4ZGVlNzA3MGE4OA==")))
+	// pf: ??staticPrefix??{SALT}{PASSWORD}
+	assert.Nil(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha1$pf=Pz9zdGF0aWNQcmVmaXg/P3tTQUxUfXtQQVNTV09SRH0=$NW9wbWtnejAzcg==$SAAxMUn7jxckQXkBmsVF0nHwqso=")))
 
-	// TODO: format strings with $ fail for some reason
-	// pf   ${PASSWORD}{SALT}$
-	assert.Nil(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha1$pf=JHtQQVNTV09SRH17U0FMVH0k$NW9wbWtnejAzcg==$M2NkZjI5MzZkYTJmYzU1NmJmYTUzM2FiMWViNTljZTcxMGFjODBlNQ==")))
+	// pf: {PASSWORD}%%{SALT}
+	assert.Nil(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha1$pf=e1BBU1NXT1JEfSUle1NBTFR9$NW9wbWtnejAzcg==$YX0AW8/MW5ojUlnzTaR43ucHCog=")))
 
+	// pf: ${PASSWORD}${SALT}$
+	assert.Nil(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha1$pf=JHtQQVNTV09SRH0ke1NBTFR9JA==$NW9wbWtnejAzcg==$iE5n1yjX3oAdxRHwZ4u57I4LpQo=")))
+
+	//SHA-256
+
+	//pf: {SALT}{PASSWORD}
+	assert.Nil(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha256$pf=e1NBTFR9e1BBU1NXT1JEfQ==$NW9wbWtnejAzcg==$0gfRVLCvtBCk20udLDEY5vNhujWx7RGjwRIS1ebMsLY=")))
+	assert.Nil(t, hash.CompareSHA(context.Background(), []byte("test"), []byte("$sha256$pf=e1NBTFR9e1BBU1NXT1JEfQ==$NW9wbWtnejAzcg==$0gfRVLCvtBCk20udLDEY5vNhujWx7RGjwRIS1ebMsLY=")))
+	assert.Error(t, hash.Compare(context.Background(), []byte("wrongpass"), []byte("$sha256$pf=e1NBTFR9e1BBU1NXT1JEfQ==$NW9wbWtnejAzcg==$0gfRVLCvtBCk20udLDEY5vNhujWx7RGjwRIS1ebMsLY=")))
+	//pf: {SALT}$${PASSWORD}
+	assert.Nil(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha256$pf=e1NBTFR9JCR7UEFTU1dPUkR9$NW9wbWtnejAzcg==$HokCOi9OtiZaZRvnkgemV3B4UUHpI7kA8zq/EZWH2NY=")))
+
+	//SHA-512
+
+	//pf: {SALT}{PASSWORD}
+	assert.Nil(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha512$pf=e1NBTFR9e1BBU1NXT1JEfQ==$NW9wbWtnejAzcg==$6ctpVuApMNp0CgBXcdHw/GC562eFEFGr4gpgANX8ZYsX+j5B19IkdmOY2Fytsz3QUwSWdGcUjbqwgJGTH0UYvw==")))
+	assert.Nil(t, hash.CompareSHA(context.Background(), []byte("test"), []byte("$sha512$pf=e1NBTFR9e1BBU1NXT1JEfQ==$NW9wbWtnejAzcg==$6ctpVuApMNp0CgBXcdHw/GC562eFEFGr4gpgANX8ZYsX+j5B19IkdmOY2Fytsz3QUwSWdGcUjbqwgJGTH0UYvw==")))
+	assert.Error(t, hash.Compare(context.Background(), []byte("wrongpass"), []byte("$sha512$pf=e1NBTFR9e1BBU1NXT1JEfQ==$NW9wbWtnejAzcg==$6ctpVuApMNp0CgBXcdHw/GC562eFEFGr4gpgANX8ZYsX+j5B19IkdmOY2Fytsz3QUwSWdGcUjbqwgJGTH0UYvw==")))
+	//pf: {SALT}$${PASSWORD}
+	assert.Nil(t, hash.Compare(context.Background(), []byte("test"), []byte("$sha512$pf=e1NBTFR9JCR7UEFTU1dPUkR9$NW9wbWtnejAzcg==$1F9BPW8UtdJkZ9Dhlf+D4X4dJ9xfuH8y04EfuCP2k4aGPPq/aWxU9/xe3LydHmYW1/K3zu3NFO9ETVrZettz3w==")))
 }


### PR DESCRIPTION
- [x] Do not use ssha validation lib due to supply chain concerns
- [x] Use PHC format for handling SHA
- We maintain though the format for {SSHA}, since it is widely used (see also [@aeneasr's comment](https://github.com/ory/kratos/pull/2741#discussion_r987569699))  
- [x] The salt position is free (like in https://github.com/ory/kratos/pull/2725)
